### PR TITLE
fix: compile on macos intel cpu is failed, Just a tip

### DIFF
--- a/clibs/zip/make.lua
+++ b/clibs/zip/make.lua
@@ -80,6 +80,12 @@ lm:source_set "zlib-ng-x86" {
             "HAVE_ATTRIBUTE_ALIGNED",
         },
     },
+    macos = {
+        defines = {
+            "HAVE_THREAD_LOCAL",
+            "HAVE_ATTRIBUTE_ALIGNED",
+        },
+    },
 }
 
 lm:source_set "zlib-ng-arm" {
@@ -144,7 +150,7 @@ lm:source_set "zlib-ng" {
         deps = "zlib-ng-x86",
     },
     macos = {
-        deps = "zlib-ng-arm",
+        deps = "zlib-ng-x86",
     },
     ios = {
         deps = "zlib-ng-arm",


### PR DESCRIPTION
I think ,the luamake may should get the macos's version , and then depend on different zlib arch?
