### PR TITLE
修复当 has_p_open 为true时，第二个返回值永远为true的bug

### DIFF
--- a/clibs/imgui/imgui_lua_funcs.cpp
+++ b/clibs/imgui/imgui_lua_funcs.cpp
@@ -807,7 +807,7 @@ static int Begin(lua_State* L) {
     auto flags = (ImGuiWindowFlags)luaL_optinteger(L, 3, lua_Integer(ImGuiWindowFlags_None));
     auto&& _retval = ImGui::Begin(name, (has_p_open? &p_open: NULL), flags);
     lua_pushboolean(L, _retval);
-    lua_pushboolean(L, has_p_open || p_open);
+    lua_pushboolean(L, !has_p_open || p_open);
     return 2;
 }
 


### PR DESCRIPTION
local ret, open = ImGui.Begin("##window_body", true, window_flag) 
修复当ImGui.Begin第二个参数为true时，第二个返回值永远为true的bug