### PR TITLE
ignore clangd .cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 res/
 .app/
 
+.cache/
 *.DS_Store
 
 editor.settings


### PR DESCRIPTION
ignore .cache folder generated by vscode extension clangd