### PR TITLE
asset manager rework

### DIFF
--- a/pkg/ant.animation_instances/animation_baker.lua
+++ b/pkg/ant.animation_instances/animation_baker.lua
@@ -106,14 +106,25 @@ local function bake_animation_mesh(anio, mesho, bakenum)
 
     local meshset = {}
 
-    local dupilcate_vb2bin
-    if mesho.meshres.vb2 then
-        dupilcate_vb2bin = mesho.meshres.vb2.str:rep(bakenum)
+    local dupilcate_vb2bin = mesho.meshres.vb2
+    if dupilcate_vb2bin then
+        dupilcate_vb2bin = dupilcate_vb2bin.str:rep(bakenum)
     end
 
     local skin      = aniobj.skins[mesho.skinning.skin]
     local wm        = mesho:load_transform()
     local numvb     = mesho:numv()
+	local ib        = mesho.meshres.ib
+	if ib then
+		-- copy this ib object from resource
+		ib = {
+			handle  = ib.handle,
+			memory  = true,	-- prevent entity delete this handle
+			start   = 0,
+			num     = ib.num,
+			flag    = ib.flag,
+		}
+	end
 
     for n, status in pairs(aniobj.status) do
         local buffers = {}
@@ -136,6 +147,7 @@ local function bake_animation_mesh(anio, mesho, bakenum)
                 num     = new_numv,
                 declname= new_vblayout,
             },
+			ib = ib,
         }
 
         if dupilcate_vb2bin then
@@ -147,16 +159,6 @@ local function bake_animation_mesh(anio, mesho, bakenum)
             }
         end
 
-        local ib = mesho.meshres.ib
-        if ib then
-            --could not share this buffer
-            newmeshobj.ib = {
-                memory  = ib.memory,
-                start   = 0,
-                num     = ib.num,
-                flag    = ib.flag,
-            }
-        end
         meshset[n] = {
             mesh                = newmeshobj,
             bakestep_ratio      = bakestep_ratio,

--- a/pkg/ant.animation_instances/animation_baker.lua
+++ b/pkg/ant.animation_instances/animation_baker.lua
@@ -135,7 +135,6 @@ local function bake_animation_mesh(anio, mesho, bakenum)
                 start   = 0,
                 num     = new_numv,
                 declname= new_vblayout,
-                owned   = true,
             },
         }
 
@@ -145,7 +144,6 @@ local function bake_animation_mesh(anio, mesho, bakenum)
                 start   = 0,
                 num     = new_numv,
                 declname= mesho.meshres.vb2.declname,
-                owned   = true,
             }
         end
 
@@ -157,7 +155,6 @@ local function bake_animation_mesh(anio, mesho, bakenum)
                 start   = 0,
                 num     = ib.num,
                 flag    = ib.flag,
-                owned   = true,
             }
         end
         meshset[n] = {

--- a/pkg/ant.animation_instances/animation_instances.lua
+++ b/pkg/ant.animation_instances/animation_instances.lua
@@ -155,7 +155,6 @@ function iai.create(prefab, framenum, numinstance, instances)
                             size    = MAX_INSTANCES,
                         }
                     },
-                    owned_mesh_buffer = true,
                     mesh_result     = imesh.init_mesh(result.mesh),
                     animation_instances = {
                         instances   = instances,

--- a/pkg/ant.asset/ext_atlas.lua
+++ b/pkg/ant.asset/ext_atlas.lua
@@ -7,6 +7,4 @@ return {
     reloader = function (name, _, block)
         return mgr.reload(name, block)
     end,
-    unloader = function ()
-    end,
 }

--- a/pkg/ant.asset/ext_material_instance.lua
+++ b/pkg/ant.asset/ext_material_instance.lua
@@ -13,11 +13,8 @@ local function loader (filename)
     return m
 end
 
-local function unloader()
-    -- temp memory will be released in render_system
-end
+-- temp memory will be released in render_system, no unloader
 
 return {
     loader = loader,
-    unloader = unloader,
 }

--- a/pkg/ant.asset/ext_meshbin.lua
+++ b/pkg/ant.asset/ext_meshbin.lua
@@ -79,7 +79,7 @@ end
 local function init(mesh)
     local vb = mesh.vb
     setmetatable(vb, proxy_vb)
-     local vb2 = mesh.vb2
+    local vb2 = mesh.vb2
     if vb2 then
         setmetatable(vb2, proxy_vb)
     end
@@ -91,17 +91,17 @@ local function init(mesh)
 end
 
 local function destroy_handle(v)
-    if v then
-        if v.owned then
-            bgfx.destroy(v.handle)
-            v.owned = nil
-        end
-        v.handle = nil
-    end
+	if v then
+		if not v.memory then
+			bgfx.destroy(v.handle)
+		end
+		v.handle = nil
+	end
 end
 
 local function delete(mesh)
     destroy_handle(mesh.vb)
+    destroy_handle(mesh.vb2)
     destroy_handle(mesh.ib)
 end
 

--- a/pkg/ant.asset/ext_ozz.lua
+++ b/pkg/ant.asset/ext_ozz.lua
@@ -11,10 +11,6 @@ local function loader(filename)
     return data
 end
 
-local function unloader()
-end
-
 return {
     loader = loader,
-    unloader = unloader,
 }

--- a/pkg/ant.asset/ext_png.lua
+++ b/pkg/ant.asset/ext_png.lua
@@ -7,6 +7,4 @@ return {
     reloader = function (name)
         return mgr.reload(name)
     end,
-    unloader = function ()
-    end,
 }

--- a/pkg/ant.asset/ext_primitive.lua
+++ b/pkg/ant.asset/ext_primitive.lua
@@ -1,0 +1,169 @@
+local renderpkg	= import_package "ant.render"
+local layoutmgr = renderpkg.layoutmgr
+local ext_meshbin 	= require "ext_meshbin"
+
+local bgfx = require "bgfx"
+
+local function create_mesh(vbdata, ibdata, aabb)
+	local vb = {
+		start = 0,
+	}
+	local mesh = {vb = vb}
+
+	if aabb then
+		mesh.bounding = {aabb=aabb}
+	end
+	
+	local correct_layout = layoutmgr.correct_layout(vbdata[1])
+	local flag = layoutmgr.vertex_desc_str(correct_layout)
+
+	vb.num = #vbdata[2] // #flag
+	vb.declname = correct_layout
+	vb.memory = {flag, vbdata[2]}
+
+	if ibdata then
+		mesh.ib = {
+			start = 0, num = #ibdata,
+			memory = {"w", ibdata},
+		}
+	end
+	return ext_meshbin.init(mesh)
+end
+
+local primitive = {}
+
+function primitive.plane(u0, v0, u1, v1)
+	if not u0 then
+		u0, v0, u1, v1 = 0, 0, 1, 1
+	end
+	local vb = {
+		-0.5, 0, 0.5, 0, 1, 0, u0, v0,	--left top
+		 0.5, 0, 0.5, 0, 1, 0, u1, v0,	--right top
+		-0.5, 0,-0.5, 0, 1, 0, u0, v1,	--left bottom
+		 0.5, 0,-0.5, 0, 1, 0, u1, v1,	--right bottom
+	}
+	return create_mesh({"p3|n3|t2", vb}, {0, 1, 2, 1, 3, 2}, {{-0.5, 0, -0.5}, {0.5, 0, 0.5}})
+end
+
+--forward to z-axis, as 1 size
+function primitive:arrow(headratio, arrowlen, coneradius, cylinderradius)
+	arrowlen = arrowlen or 1
+	headratio = headratio or 0.15
+	local headlen<const> = arrowlen * (1.0-headratio)
+	local fmt<const> = "fff"
+	local layout<const> = layoutmgr.get "p3"
+
+	coneradius	= coneradius or 0.1
+	cylinderradius	= cylinderradius or coneradius * 0.5
+	local slicenum<const> 		= 10
+	local deltaradian<const> 	= math.pi*2/slicenum
+
+	local numv<const>			= slicenum*3+3	--3 center points
+	local vb = bgfx.memory_buffer(layout.stride*numv)
+	local function add_v(idx, x, y, z)
+		local vboffset = layout.stride*idx+1
+		vb[vboffset] = fmt:pack(x, y, z)
+	end
+
+	add_v(0,0.0, 0.0, arrowlen)
+	add_v(1,0.0, 0.0, headlen)
+	add_v(2,0.0, 0.0, 0.0)
+
+	local offset=3
+
+	for i=0, slicenum-1 do
+		local r = deltaradian*i
+		local c, s = math.cos(r), math.sin(r)
+		local idx = i+offset
+		add_v(idx,	c*coneradius, s*coneradius, headlen)
+
+		local idx1 = idx+slicenum
+		add_v(idx1,	c*cylinderradius, s*cylinderradius, headlen)
+		
+		local idx2 = idx1+slicenum
+		add_v(idx2, c*cylinderradius, s*cylinderradius, 0.0)
+	end
+
+	local numtri<const>		= slicenum*5	--3 circle + 1 quad
+	local ibstride<const>	= 2
+	local numi<const>		= numtri*3
+	local ib = bgfx.memory_buffer(ibstride*numtri*3)
+	local ibfmt<const> = "HHH"
+	local iboffset = 1
+	local function add_t(i0, i1, i2)
+		ib[iboffset] = ibfmt:pack(i0, i1, i2)
+		iboffset = iboffset + ibstride*3
+	end
+
+	local ic1, ic2, ic3 = 0, 1, 2
+	local cc1 = ic3+1
+	local cc2 = cc1+slicenum
+	local cc3 = cc2+slicenum
+
+	--
+	for i=0, slicenum-1 do
+		--cone
+		do
+			local i2, i3 = cc1+i, cc1+i+1
+			if i == slicenum-1 then
+				i3 = cc1
+			end
+			add_t(ic1, i2, i3)
+			add_t(ic2, i3, i2)
+		end
+
+		do
+			--cylinder quad
+			local v0 = cc2+i
+			local v1 = cc3+i
+			local v2 = v1+1
+			local v3 = v0+1
+
+			if i == slicenum-1 then
+				v2 = cc3
+				v3 = cc2
+			end
+			
+			add_t(v0, v1, v2)
+			add_t(v2, v3, v0)
+
+			add_t(ic3, v2, v1)
+		end
+	end
+	return {
+		vb = {
+			start = 0,
+			num = numv,
+			declname = "p3",
+			handle = bgfx.create_vertex_buffer(vb, layout.handle),
+		},
+		ib = {
+			start = 0,
+			num = numi,
+			handle = bgfx.create_index_buffer(ib),
+		}
+	}
+end
+
+local function loader(fullname)
+	local name = fullname:match "(.+)%.primitive$"
+	local create = primitive[name]
+	if create then
+		return create()
+	end
+	local name, args = name:match "(.+)(%b())$"
+	create = primitive[name] or error ("No primitive type : " .. fullname)
+	local t = {}
+	local n = 1
+	for v in args:sub(2,-2):gmatch "[^,]+" do
+		t[n] = tonumber(v) or v
+		n = n + 1			
+	end
+	
+	return create(table.unpack(t))
+end
+
+return {
+	loader = loader,
+	unloader = ext_meshbin.delete,
+}

--- a/pkg/ant.asset/ext_skinbin.lua
+++ b/pkg/ant.asset/ext_skinbin.lua
@@ -12,6 +12,4 @@ return {
             jointsRemap = ozz.Uint16Verctor(data.jointsRemap)
         }
     end,
-    unloader = function (res)
-    end
 }

--- a/pkg/ant.asset/ext_texture.lua
+++ b/pkg/ant.asset/ext_texture.lua
@@ -7,6 +7,4 @@ return {
     reloader = function (name, _, block)
         return mgr.reload(name, block)
     end,
-    unloader = function ()
-    end,
 }

--- a/pkg/ant.asset/main.lua
+++ b/pkg/ant.asset/main.lua
@@ -100,9 +100,11 @@ function assetmgr.flush()
 	for ext, cache in pairs(EXTLIST) do
 		local del = cache()	-- flush cache
 		if del then
-			local api = require_ext(ext)
-			for _, v in ipairs(del) do
-				api.unloader(v)
+			local unload = require_ext(ext).unloader
+			if unload then
+				for _, v in ipairs(del) do
+					unload(v)
+				end
 			end
 		end
 	end

--- a/pkg/ant.asset/main.lua
+++ b/pkg/ant.asset/main.lua
@@ -4,10 +4,68 @@ local sa			= require "system_attribs"	-- must require after 'texture_mgr.init()'
 
 local assetmgr = {}
 
-local FILELIST = {}
+local function gen_cache()
+	local cache_meta = {}
+	local old_n = 0
+	local new_n = 0
+	local old = {}
+
+	function cache_meta:__index(name)
+		local v = old[name]
+		if v then
+			old[name] = nil
+			old_n = old_n - 1
+			self[name] = v
+			return v
+		end
+	end
+
+	function cache_meta:__newindex(name, v)
+		new_n = new_n + 1
+		rawset(self, name, v)
+	end
+
+	-- flush cache
+	function cache_meta:__call()
+		local ret
+		local cap = new_n * 2 + old_n // 2
+		local total = old_n + new_n - cap
+		if total > 0 then
+			ret = {}
+			for i = 1, total do
+				local k,v = next(old)
+				ret[i] = v
+				old[k] = nil
+				old_n = old_n - 1
+			end
+		end
+		for k,v in pairs(self) do
+			old[k] = v
+			self[k] = nil
+			old_n = old_n + 1
+		end
+		new_n = 0
+		return ret
+	end
+
+	return setmetatable({}, cache_meta)
+end
 
 local function require_ext(ext)
 	return require("ext_" .. ext)
+end
+
+local EXTLIST = setmetatable({}, {
+	__index = function(self, ext)
+		local list = gen_cache(require_ext(ext))
+		self[ext] = list
+		return list
+	end
+})
+
+local function get_cache(fullpath)
+	local ext = fullpath:match "[^.]*$"
+	return EXTLIST[ext], require_ext(ext)
 end
 
 function assetmgr.init()
@@ -19,33 +77,35 @@ function assetmgr.init()
 end
 
 function assetmgr.load(fullpath, block)
+	local FILELIST, api = get_cache(fullpath)
 	local robj = FILELIST[fullpath]
 	if not robj then
-		local ext = fullpath:match "[^.]*$"
-		robj = require_ext(ext).loader(fullpath, block)
+		robj = api.loader(fullpath, block)
 		FILELIST[fullpath] = robj
 	end
 	return robj
-end
-
-function assetmgr.unload(fullpath)
-	local robj = FILELIST[fullpath]
-	if robj == nil then
-		return
-	end
-	local ext = fullpath:match "[^.]*$"
-	require_ext(ext).unloader(robj)
-	FILELIST[fullpath] = nil
 end
 
 function assetmgr.reload(fullpath, block)
+	local FILELIST, api = get_cache(fullpath)
 	local robj = FILELIST[fullpath]
 	if robj then
-		local ext = fullpath:match "[^.]*$"
-		robj = require_ext(ext).reloader(fullpath, robj, block)
+		robj = api.reloader(fullpath, robj, block)
 		FILELIST[fullpath] = robj
 	end
 	return robj
+end
+
+function assetmgr.flush()
+	for ext, cache in pairs(EXTLIST) do
+		local del = cache()	-- flush cache
+		if del then
+			local api = require_ext(ext)
+			for _, v in ipairs(del) do
+				api.unloader(v)
+			end
+		end
+	end
 end
 
 assetmgr.resource = assetmgr.load

--- a/pkg/ant.entity/entity.lua
+++ b/pkg/ant.entity/entity.lua
@@ -46,13 +46,11 @@ local function create_mesh(vbdata, ibdata, aabb)
 	vb.num = #vbdata[2] // #flag
 	vb.declname = correct_layout
 	vb.memory = {flag, vbdata[2]}
-	vb.owned = true
 
 	if ibdata then
 		mesh.ib = {
 			start = 0, num = #ibdata,
 			memory = {"w", ibdata},
-			owned = true,
 		}
 	end
 	return imesh.init_mesh(mesh)
@@ -452,7 +450,6 @@ local function get_skybox_mesh()
 		local desc = {vb={}, ib={}}
 		geodrawer.draw_box({1, 1, 1}, nil, nil, desc)
 		skybox_mesh = create_mesh({"p3", desc.vb}, desc.ib)
-		skybox_mesh.ib.owned, skybox_mesh.vb.owned = true, true
 	end
 
 	return skybox_mesh
@@ -475,7 +472,6 @@ function ientity.create_skybox(material)
 				LUT = {size=256},
 			},
 			skybox = {},
-			owned_mesh_buffer = true,
 			mesh_result = get_skybox_mesh(),
 		}
 	}
@@ -542,7 +538,6 @@ function ientity.create_procedural_sky(settings)
 				}
 			},
 			visible = true,
-			owned_mesh_buffer = true,
 			render_layer = "background",
 			mesh_result = create_sky_mesh(32, 32),
 		}
@@ -573,10 +568,8 @@ function ientity.create_gamma_test_entity()
 						420, 200, 1.0, 0.0,
 						420, 132, 1.0, 1.0,
 					}), layoutmgr.get "p2|t2".handle),
-					owned = true,
                 }
             },
-			owned_mesh_buffer = true,
             scene = {},
             visible = true,
         }
@@ -674,13 +667,11 @@ local function arrow_mesh(headratio, arrowlen, coneradius, cylinderradius)
 			num = numv,
 			declname = "p3",
 			handle = bgfx.create_vertex_buffer(vb, layout.handle),
-			owned = true,
 		},
 		ib = {
 			start = 0,
 			num = numi,
 			handle = bgfx.create_index_buffer(ib),
-			owned = true,
 		}
 	}
 end
@@ -697,7 +688,6 @@ function ientity.create_arrow_entity(headratio, color, material, scene)
 			material = material,
 			visible = true,
 			scene = scene or {},
-            owned_mesh_buffer = true,
 			on_ready = function (e)
 				imaterial.set_property(e, "u_color", math3d.vector(color))
 			end
@@ -771,7 +761,6 @@ function ientity.create_quad_entity(material, srt, rect, uvrect)
         data = {
             material 	= material,
             mesh_result = ientity.quad_mesh(rect, true, uvrect),
-            owned_mesh_buffer = true,
             visible		= true,
             scene 		= srt,
             render_layer= "translucent",

--- a/pkg/ant.entity/entity.lua
+++ b/pkg/ant.entity/entity.lua
@@ -195,23 +195,6 @@ function ientity.create_grid_entity(width, height, unit, linewidth, srt, materia
 	ipl.add_linelist({{0, 0, -hh_len}, {0, 0, hh_len},}, centerwidth, {0.0, 0.0, c, 1.0}, material, srt, render_layer)
 end
 
-
-function ientity.plane_mesh(tex_uv)
-	local u0, v0, u1, v1
-	if tex_uv then
-		u0, v0, u1, v1 = tex_uv[1], tex_uv[2], tex_uv[3], tex_uv[4]
-	else
-		u0, v0, u1, v1 = 0, 0, 1, 1
-	end
-	local vb = {
-		-0.5, 0, 0.5, 0, 1, 0, u0, v0,	--left top
-		 0.5, 0, 0.5, 0, 1, 0, u1, v0,	--right top
-		-0.5, 0,-0.5, 0, 1, 0, u0, v1,	--left bottom
-		 0.5, 0,-0.5, 0, 1, 0, u1, v1,	--right bottom
-	}
-	return create_mesh({"p3|n3|t2", vb}, {0, 1, 2, 1, 3, 2}, {{-0.5, 0, -0.5}, {0.5, 0, 0.5}})
-end
-
 local plane_vb<const> = {
 	-0.5, 0, 0.5, 0, 1, 0,	--left top
 	0.5,  0, 0.5, 0, 1, 0,	--right top
@@ -676,15 +659,13 @@ local function arrow_mesh(headratio, arrowlen, coneradius, cylinderradius)
 	}
 end
 
-ientity.arrow_mesh = arrow_mesh
-
 function ientity.create_arrow_entity(headratio, color, material, scene)
 	return world:create_entity{
 		policy = {
-			"ant.render|simplerender",
+			"ant.render|render",
 		},
 		data = {
-			mesh_result = arrow_mesh(headratio),
+			mesh = "arrow(" .. headratio .. ").primitive",
 			material = material,
 			visible = true,
 			scene = scene or {},

--- a/pkg/ant.landform/road.lua
+++ b/pkg/ant.landform/road.lua
@@ -202,6 +202,12 @@ local function destroy_handle(h)
     end
 end
 
+function road_sys:entity_init()
+    for e in w:select "INIT road owned_mesh_buffer:out" do
+		e.owned_mesh_buffer = false
+    end
+end
+
 function road_sys:entity_remove()
     for e in w:select "REMOVED road:in" do
         e.road.handle = destroy_handle(e.road.handle)

--- a/pkg/ant.objcontroller/pickup/pickup_debug.lua
+++ b/pkg/ant.objcontroller/pickup/pickup_debug.lua
@@ -26,13 +26,11 @@ local pickup_debug_sys = ecs.system "pickup_debug_system"
 
 local function create_view_buffer_entity()
 	local m = ientity.quad_mesh(mu.texture_uv{x=0,y=0,w=120, h=120})
-	m.ib.owned, m.vb.owned = true, true
 	world:create_entity{
 		policy = {
 			"ant.render|simplerender",
 		},
 		data = {
-			owned_mesh_buffer = true,
 			mesh_result = m,
 			material = "/pkg/ant.resources/materials/texquad.material",
 			visible = true,

--- a/pkg/ant.polyline/polyline.lua
+++ b/pkg/ant.polyline/polyline.lua
@@ -24,7 +24,17 @@ local ipl       = {}
     vec3  v_texcoord0;  //xy for uv, w for counter
 ]]
 
-
+-- todo: Need better solution to release this handle
+-- try to use asset manager ?
+local release_handle = {
+	__gc = function(self)
+		local h = self.handle
+		if h then
+			self.handle = nil
+			bgfx.destroy(h)
+		end
+	end
+}
 
 local function create_strip_index_buffer(max_lines)
     local function create_ib_buffer(max_lines)
@@ -46,27 +56,11 @@ local function create_strip_index_buffer(max_lines)
         return bgfx.create_index_buffer(indices)
     end
 
-    return {
+    return setmetatable( {
         offset = 0,
         num_indices = max_lines,
         handle = create_ib_buffer(max_lines),
-        alloc = function (self, numlines)
-            local numindices<const> = numlines * 2 * 3
-            local start = self.offset
-        
-            if start + numindices > self.num_indices then
-                error(("not enough index buffer:%d, %d"):format(start+numindices, self.num_indices))
-            end
-        
-            self.offset = start + numindices
-        
-            return {
-                start = start,
-                num = numindices,
-                handle = self.handle,
-            }
-        end
-    }
+    }, release_handle)
 end
 
 local strip_ib = create_strip_index_buffer(3072)

--- a/pkg/ant.polyline/polyline.lua
+++ b/pkg/ant.polyline/polyline.lua
@@ -198,12 +198,12 @@ function ipl.create_linestrip_mesh(points, line_width, color, uv_rotation, loop)
             start = 0,
             num = numlines * 2 * 3,
             handle = strip_ib.handle,
+			memory = true,	-- prevent to delete this handle
         },
         vb = {
             start = 0,
             num = numv,
             handle = bgfx.create_vertex_buffer(vertices, stripline_desc.layout.handle),
-            owned = true,
         },
     }
 end
@@ -270,12 +270,12 @@ function ipl.create_linelist_mesh(pointlist, line_width, color)
             start = 0,
             num = numlines * 2 * 3,
             handle = irender.quad_ib(),
+			memory = true,	-- prevent to delete ib.handle
         },
         vb = {
             start = 0,
             num = numv,
             handle = bgfx.create_vertex_buffer(vertices, linelist_desc.layout.handle),
-            owned = true,
         }
     }
 end

--- a/pkg/ant.render/postprocess/taa.lua
+++ b/pkg/ant.render/postprocess/taa.lua
@@ -52,7 +52,6 @@ function taasys:init()
         vb = {
             start = 0, num = 3,
             handle = fullquad_vbhandle,
-            owned = true,
         }
     }
     taa_first_frame_eid = world:create_entity{
@@ -63,7 +62,6 @@ function taasys:init()
             mesh_result     = fullquad,
             material        = "/pkg/ant.resources/materials/postprocess/taa_first_frame.material",
             visible_masks   = "",
-            owned_mesh_buffer = true,
             taa_first_frame_drawer     = true,
             scene           = {},
         }

--- a/pkg/ant.render/render_system/render_system.lua
+++ b/pkg/ant.render/render_system/render_system.lua
@@ -156,6 +156,9 @@ function render_sys:component_init()
 		ro.mesh_idx		= MESH.alloc()
 	end
 
+	-- The entity created with mesh_result should delete handles by themselves
+	w:filter("owned_mesh_buffer", "INIT mesh_result")
+
 	for e in w:select "INIT mesh:in mesh_result:out" do
 		e.mesh_result = assetmgr.resource(e.mesh)
 	end
@@ -319,6 +322,8 @@ local function clear_render_object(ro)
 end
 
 function render_sys:entity_remove()
+	-- the mesh handle with owned_mesh_buffer should delete with entity
+	-- otherwise the handles would be managed by asset manager
 	for e in w:select "REMOVED owned_mesh_buffer mesh_result:in" do
 		imesh.delete_mesh(e.mesh_result)
 	end

--- a/pkg/ant.render/render_system/render_system.lua
+++ b/pkg/ant.render/render_system/render_system.lua
@@ -157,7 +157,8 @@ function render_sys:component_init()
 	end
 
 	-- The entity created with mesh_result should delete handles by themselves
-	w:filter("owned_mesh_buffer", "INIT mesh_result")
+	-- If entity has mesh, mesh_result must be false
+	w:filter("owned_mesh_buffer", "INIT mesh:absent mesh_result", true)
 
 	for e in w:select "INIT mesh:in mesh_result:out" do
 		e.mesh_result = assetmgr.resource(e.mesh)

--- a/pkg/ant.render/shadow/shadow_debug.lua
+++ b/pkg/ant.render/shadow/shadow_debug.lua
@@ -215,7 +215,6 @@ local function draw_lines(lines)
 			scene = {},
 			render_layer = "translucent",
 			visible = true,
-			owned_mesh_buffer = true,
 		}
 	}
 end
@@ -258,7 +257,6 @@ local function draw_box(points, M)
 			scene = {},
 			render_layer = "translucent",
 			visible = true,
-			owned_mesh_buffer = true,
 		}
 	}
 end

--- a/pkg/ant.sky/skybox.lua
+++ b/pkg/ant.sky/skybox.lua
@@ -9,7 +9,7 @@ local ientity	= ecs.require "ant.entity|entity"
 local skybox_sys = ecs.system "skybox_system"
 
 function skybox_sys:component_init()
-	for e in w:select "INIT skybox:in mesh_result?out owned_mesh_buffer?out" do
+	for e in w:select "INIT skybox:in mesh_result:out owned_mesh_buffer?out" do
 		local vb, ib = geo.box(1, true, false)
 		local m = ientity.create_mesh({"p3", vb}, ib)
 		e.mesh_result = m

--- a/pkg/ant.sky/skybox.lua
+++ b/pkg/ant.sky/skybox.lua
@@ -9,7 +9,7 @@ local ientity	= ecs.require "ant.entity|entity"
 local skybox_sys = ecs.system "skybox_system"
 
 function skybox_sys:component_init()
-	for e in w:select "INIT skybox:in mesh_result:out owned_mesh_buffer:out" do
+	for e in w:select "INIT skybox:in mesh_result?out owned_mesh_buffer?out" do
 		local vb, ib = geo.box(1, true, false)
 		local m = ientity.create_mesh({"p3", vb}, ib)
 		e.mesh_result = m

--- a/pkg/ant.sky/skybox.lua
+++ b/pkg/ant.sky/skybox.lua
@@ -9,7 +9,7 @@ local ientity	= ecs.require "ant.entity|entity"
 local skybox_sys = ecs.system "skybox_system"
 
 function skybox_sys:component_init()
-	for e in w:select "INIT skybox:in mesh_result:out owned_mesh_buffer?out" do
+	for e in w:select "INIT skybox:in mesh_result:out owned_mesh_buffer:out" do
 		local vb, ib = geo.box(1, true, false)
 		local m = ientity.create_mesh({"p3", vb}, ib)
 		e.mesh_result = m

--- a/pkg/ant.starsky/starsky.lua
+++ b/pkg/ant.starsky/starsky.lua
@@ -17,7 +17,7 @@ local function get_tex_ratio(vr, texinfo)
 end
 
 function starsky_system:component_init()
-    for e in w:select "INIT starsky mesh_result:out owned_mesh_buffer:out" do
+    for e in w:select "INIT starsky mesh_result:out owned_mesh_buffer?out" do
         local mq = w:first "main_queue render_target:in camera_ref:in"
         local vr = mq.render_target.view_rect
         local texinfo =  assetmgr.resource("/pkg/vaststars.resources/textures/sky/star_sky.texture").texinfo

--- a/pkg/ant.starsky/starsky.lua
+++ b/pkg/ant.starsky/starsky.lua
@@ -17,7 +17,7 @@ local function get_tex_ratio(vr, texinfo)
 end
 
 function starsky_system:component_init()
-    for e in w:select "INIT starsky mesh_result:out owned_mesh_buffer?out" do
+    for e in w:select "INIT starsky mesh_result:out owned_mesh_buffer:out" do
         local mq = w:first "main_queue render_target:in camera_ref:in"
         local vr = mq.render_target.view_rect
         local texinfo =  assetmgr.resource("/pkg/vaststars.resources/textures/sky/star_sky.texture").texinfo

--- a/pkg/ant.terrain/canvas.lua
+++ b/pkg/ant.terrain/canvas.lua
@@ -191,15 +191,14 @@ local function create_texture_item_entity(canvas_eid, show, materialpath, render
                     start = 0,
                     num = 0,
                     handle = bgfx.create_dynamic_vertex_buffer(1, layout.handle, "a"),
-                    owned = true
                 },
                 ib = {
                     start = 0,
                     num = 0,
                     handle = irender.quad_ib(),
+					memory = true,	-- prevent to delete ib.handle
                 }
             },
-            owned_mesh_buffer = true,
             material    = materialpath,
             scene       = {
                 parent = canvas_eid,

--- a/pkg/ant.terrain/quad_strip.lua
+++ b/pkg/ant.terrain/quad_strip.lua
@@ -51,7 +51,6 @@ function qs_sys:entity_init()
             },
             data = {
                 mesh_result = quadstrip_mesh,
-                owned_mesh_buffer = true,
                 material = e.material,
                 visible = true,
                 scene = {

--- a/pkg/ant.terrain/water_system.lua
+++ b/pkg/ant.terrain/water_system.lua
@@ -57,7 +57,7 @@ local function gen_water_grid_mesh(gw, gh, unit, height)
 end
 
 function water_sys:component_init()
-    for e in w:select "INIT water:in mesh_result:out owned_mesh_buffer:out" do
+    for e in w:select "INIT water:in mesh_result:out owned_mesh_buffer?out" do
         local water = e.water
         local gw, gh = water.grid_width, water.grid_height
         local unit = water.unit

--- a/pkg/ant.terrain/water_system.lua
+++ b/pkg/ant.terrain/water_system.lua
@@ -57,7 +57,7 @@ local function gen_water_grid_mesh(gw, gh, unit, height)
 end
 
 function water_sys:component_init()
-    for e in w:select "INIT water:in mesh_result:out owned_mesh_buffer?out" do
+    for e in w:select "INIT water:in mesh_result:out owned_mesh_buffer:out" do
         local water = e.water
         local gw, gh = water.grid_width, water.grid_height
         local unit = water.unit

--- a/pkg/ant.widget/widget.lua
+++ b/pkg/ant.widget/widget.lua
@@ -25,13 +25,11 @@ local function create_dynamic_buffer(layout, num_vertices, num_indices)
 			num = 0,
 			declname = "p3|c40niu",
 			handle=bgfx.create_dynamic_vertex_buffer(vb_size, layoutmgr.get(layout).handle, "a"),
-			owned = true,
 		},
 		ib = {
 			start = 0,
 			num = 0,
 			handle = bgfx.create_dynamic_index_buffer(ib_size, "a"),
-			owned = true,
 		}
 	}
 end
@@ -50,7 +48,6 @@ function widget_drawer_sys:init()
 		data = {
 			scene = {},
 			mesh_result = create_dynamic_buffer(wd.declname, wd.vertices_num, wd.indices_num),
-			owned_mesh_buffer = true,
 			material = "/pkg/ant.resources/materials/line.material",
 			render_layer = "translucent",
 			visible = true,

--- a/pkg/ant.world/main.lua
+++ b/pkg/ant.world/main.lua
@@ -1,5 +1,6 @@
 local luaecs = import_package "ant.luaecs"
 local serialize = import_package "ant.serialize"
+local assetmgr = import_package "ant.asset"
 local btime = require "bee.time"
 local inputmgr = require "inputmgr"
 local bgfx = require "bgfx"
@@ -735,6 +736,7 @@ function m.new_world(config)
     inputmgr.init(w)
 
     log.info "world initializing"
+	assetmgr.flush()
     feature.import(w, config.ecs.feature)
     cworld.create(w)
     for _, funcs in pairs(w._clibs_loaded) do

--- a/test/features/pkg/ant.test.features/test/point_light_test.lua
+++ b/test/features/pkg/ant.test.features/test/point_light_test.lua
@@ -51,7 +51,7 @@ end
 local function shadow_plane()
     return PC:create_entity{
 		policy = {
-			"ant.render|simplerender",
+			"ant.render|render",
 		},
 		data = {
 			scene 		= {
@@ -59,7 +59,7 @@ local function shadow_plane()
 				s = {100, 1, 100},
             },
 			material 	= "/pkg/ant.resources/materials/mesh_shadow.material",
-			mesh_result	= ientity.plane_mesh(),
+			mesh		= "plane.primitive",
             visible     = true,
 		}
 	}

--- a/test/features/pkg/ant.test.features/test/render_layer_test.lua
+++ b/test/features/pkg/ant.test.features/test/render_layer_test.lua
@@ -7,7 +7,6 @@ local util  = ecs.require "util"
 local PC    = util.proxy_creator()
 
 local irl       = ecs.require "ant.render|render_layer.render_layer"
-local ientity   = ecs.require "ant.entity|entity"
 local imesh     = ecs.require "ant.asset|mesh"
 local imaterial = ecs.require "ant.render|material"
 local iom       = ecs.require "ant.objcontroller|obj_motion"
@@ -32,10 +31,10 @@ function rlt_sys.init_world()
 
     PC:create_entity {
         policy = {
-            "ant.render|simplerender",
+            "ant.render|render",
         },
         data = {
-            mesh_result= ientity.plane_mesh(),
+            mesh = "plane.primitive",
             scene = {t = {-10, 0, 0}, s = 10},
             material = "/pkg/ant.test.features/assets/render_layer_test.material",
             render_layer = "translucent_plane",

--- a/test/features/pkg/ant.test.features/test/shadow_test.lua
+++ b/test/features/pkg/ant.test.features/test/shadow_test.lua
@@ -67,11 +67,11 @@ end
 local function plane_entity(srt)
 	return world:create_entity{
 		policy = {
-			"ant.render|simplerender",
+			"ant.render|render",
 		},
 		data = {
 			scene 		= srt,
-            mesh_result = ientity.plane_mesh(),
+            mesh		= "plane.primitive",
 			material 	= "/pkg/ant.resources/materials/mesh_shadow.material",
 			visible_masks = "main_view|cast_shadow",
 			cast_shadow = true,

--- a/test/features/pkg/ant.test.features/test/texture_test.lua
+++ b/test/features/pkg/ant.test.features/test/texture_test.lua
@@ -43,10 +43,8 @@ function dtt_sys:init()
                         bgfx.memory_buffer("fffff", m),
                         layout.handle
                     ),
-                    owned = true,
                 },
             },
-            owned_mesh_buffer = true,
             on_ready = function (e)
                 local x, y, ww, hh = 0, 0, 1, 1
                 local gen_mipmap = false

--- a/test/features/pkg/ant.test.features/util.lua
+++ b/test/features/pkg/ant.test.features/util.lua
@@ -2,20 +2,17 @@ local ecs   = ...
 local world = ecs.world
 local w     = world.w
 
-local imesh   = ecs.require "ant.asset|mesh"
-local ientity = ecs.require "ant.entity|entity"
-
 local util = {}
 
 function util.create_shadow_plane(sx, sz)
     sz = sz or sx
     return world:create_entity{
 		policy = {
-			"ant.render|simplerender",
+			"ant.render|render",
 		},
 		data = {
 			scene 		= {s = {sx, 1, sz},},
-            mesh_result = imesh.init_mesh(ientity.plane_mesh()),
+			mesh        = "plane.primitive",
 			material 	= "/pkg/ant.resources/materials/mesh_shadow.material",
 			visible     = true,
 		}

--- a/test/simple/pkg/ant.test.simple/main_system.lua
+++ b/test/simple/pkg/ant.test.simple/main_system.lua
@@ -29,7 +29,6 @@ function m:init_world()
 			material 	= "/pkg/ant.resources/materials/mesh_shadow.material",
 			visible     = true,
 			mesh_result	= ientity.plane_mesh(),
-            owned_mesh_buffer = true,
 		}
 	}
 

--- a/test/simple/pkg/ant.test.simple/main_system.lua
+++ b/test/simple/pkg/ant.test.simple/main_system.lua
@@ -10,17 +10,13 @@ local m = ecs.system "main_system"
 
 local prefab
 
-local imesh = ecs.require "ant.asset|mesh"
-local ientity = ecs.require "ant.entity|entity"
-
 function m:init_world()
     world:create_instance {
         prefab = "/pkg/ant.test.simple/resource/light.prefab"
     }
-
-    world:create_entity{
+	world:create_entity{
 		policy = {
-			"ant.render|simplerender",
+			"ant.render|render",
 		},
 		data = {
 			scene 		= {
@@ -28,7 +24,7 @@ function m:init_world()
             },
 			material 	= "/pkg/ant.resources/materials/mesh_shadow.material",
 			visible     = true,
-			mesh_result	= ientity.plane_mesh(),
+			mesh        = "plane.primitive",
 		}
 	}
 

--- a/test/simple_rt/pkg/ant.test.simple/main_system.lua
+++ b/test/simple_rt/pkg/ant.test.simple/main_system.lua
@@ -9,7 +9,6 @@ local util      = ecs.require "ant.render|postprocess.util"
 local queuemgr  = ecs.require "ant.render|queue_mgr"
 local irq       = ecs.require "ant.render|renderqueue"
 local imesh     = ecs.require "ant.asset|mesh"
-local ientity   = ecs.require "ant.entity|entity"
 local hwi       = import_package "ant.hwi"
 local irender   = ecs.require "ant.render|render"
 local mu        = import_package "ant.math".util
@@ -100,7 +99,7 @@ local function create_scene(is_test)
 
     local plane = world:create_entity{
 		policy = {
-			"ant.render|simplerender",
+			"ant.render|render",
 		},
 		data = {
 			scene 		= {
@@ -109,7 +108,7 @@ local function create_scene(is_test)
 			material 	= "/pkg/ant.resources/materials/mesh_shadow.material",
 			visible     = true,
             visible_masks = is_test and "" or nil,
-			mesh_result	= ientity.plane_mesh(),
+			mesh		= "plane.primitive",
 		}
 	}
 

--- a/test/simple_rt/pkg/ant.test.simple/main_system.lua
+++ b/test/simple_rt/pkg/ant.test.simple/main_system.lua
@@ -110,7 +110,6 @@ local function create_scene(is_test)
 			visible     = true,
             visible_masks = is_test and "" or nil,
 			mesh_result	= ientity.plane_mesh(),
-            owned_mesh_buffer = true,
 		}
 	}
 

--- a/tools/editor/pkg/tools.editor/camera/second_view.lua
+++ b/tools/editor/pkg/tools.editor/camera/second_view.lua
@@ -188,7 +188,6 @@ local function create_frustum_entity(eid)
         data = {
             on_ready = onready,
             mesh_result = ientity.create_mesh({"p3", vb}, frustum_ib),
-            owned_mesh_buffer = true,
             material = "/pkg/ant.resources/materials/line_color.material",
             render_layer = "translucent",
             scene = { parent = frustum_root },
@@ -217,7 +216,6 @@ local function create_frustum_entity(eid)
                      hl, 0.0, 0.0,
                 }
             },
-            owned_mesh_buffer = true,
             material = "/pkg/ant.resources/materials/singlecolor.material",
             visible = true,
             scene = {

--- a/tools/editor/pkg/tools.editor/gizmo/navi_gizmo.lua
+++ b/tools/editor/pkg/tools.editor/gizmo/navi_gizmo.lua
@@ -69,7 +69,6 @@ local function create_navi_obj(material, size, zvalue)
             visible = false,
             material = material,
             mesh_result = ientity.create_mesh{"p3|t2", vbdata},
-            owned_mesh_buffer = true,
         }
     }
 end

--- a/tools/editor/pkg/tools.editor/prefab_manager.lua
+++ b/tools/editor/pkg/tools.editor/prefab_manager.lua
@@ -64,7 +64,6 @@ local function create_light_billboard(light_eid, lighttype)
             visible = true,
             material = "/pkg/tools.editor/resource/materials/billboard_"..lighttype..".material",
             mesh_result = ientity.create_mesh{"p3|t2", vbdata},
-            owned_mesh_buffer = true,
         }
     }
 end

--- a/tools/editor/pkg/tools.editor/prefab_manager.lua
+++ b/tools/editor/pkg/tools.editor/prefab_manager.lua
@@ -950,9 +950,10 @@ function m:save(path)
             end
             if #final_template > 0 then
                 utils.write_file(self.glb_filename..".patch", stringify(final_template))
-                assetmgr.unload(gd.virtual_glb_path.."/" .. self.anim_file)
-                assetmgr.unload(self.glb_filename..".patch")
-                assetmgr.unload(self.glb_filename.."/"..self.prefab_name)
+-- TODO: do not use unload, use assetmgr.flush instead				
+--                assetmgr.unload(gd.virtual_glb_path.."/" .. self.anim_file)
+--                assetmgr.unload(self.glb_filename..".patch")
+--                assetmgr.unload(self.glb_filename.."/"..self.prefab_name)
                 world:pub {"Save"}
             end
         end

--- a/tools/editor/pkg/tools.editor/widget/keyframe_view.lua
+++ b/tools/editor/pkg/tools.editor/widget/keyframe_view.lua
@@ -1428,7 +1428,6 @@ local function create_bone_entity(joint_name)
 			material	= "/pkg/tools.editor/resource/materials/joint.material",
             render_layer = "translucent",
 			mesh_result	= ientity.create_mesh({"p3|n3|t2", bone_vert}),
-            owned_mesh_buffer = true,
 			visible = true,
             visible_masks = "selectable",
 			on_ready 	= function(e)

--- a/tools/editor/pkg/tools.editor/widget/uiproperty.lua
+++ b/tools/editor/pkg/tools.editor/widget/uiproperty.lua
@@ -345,7 +345,8 @@ function TextureResource:show()
                 local path = fs.path(payload);
                 if path:extension() == ".png" or path:extension() == ".dds" then
                     self:set_file(tostring(path))
-                    assetmgr.unload(self.path)
+-- TODO: do not use unload, use assetmgr.flush instead				
+--                  assetmgr.unload(self.path)
                 end
             end
             ImGui.EndDragDropTarget()


### PR DESCRIPTION
目前在重做 Asset 管理模块，见 https://blog.codingnow.com/2024/06/asset_mgr_rework.html

第一步：简化 entity 自我管理 mesh buffer 。

1. 去掉了 owned 标记，因为在 entity 上已有 `owned_mesh_buffer` 这个 tag 标识 entity 是否应该在 entity 销毁时同时删除 mesh buffer 。之前的实现有问题，在 buffer 对象上加上 owned 标记，会导致 asset manager 自身也无法通过 unload 方法销毁 handle 。

有部分 owned mesh 共享了 ib ，不应在销毁 entity 时销毁共享 ib 。此处用了一个小技巧，在 buffer 对象中设置 .memory = true 。销毁时检查 .memory 。同时，这个检查也可以避免未通过 meta 方法从 .memory 转换到 .handle 的情况，做不必要的转换再销毁 handle 。

2. 不再需要调用者来打 `owned_mesh_buffer` 这个 tag ，太容易出错了，之前的版本已经发现至少一处在创建 entity 时遗漏了该 tag 。目前改在 `render_sys:component_init()` 中统一把已带有 `mesh_result` 组件的 entity 统一加上 tag 。这个使用了 luaecs.filter 方法。

```lua
w:filter("owned_mesh_buffer", "INIT mesh_result")
```

3. 之前有遗漏，没有销毁 .vb2 。

第二步 ：为 asset 增加了 flush 的 cache 机制，并移除了 unload 。

目前，只在 world 创建的时候主动调用了 flush 。在 vaststars 游戏中测试，看起来没有问题。ant 的测试程序中目前没有测试 reboot 的程序。建议 @junjie020 把 test.features 改成用重新创建 world 的方式来切换测试案例？或者另外专门写一个 reboot world 的 test @actboy168 。

编辑器方面，我看到有几处使用了 unload 卸载 prefab 。看起来必要性不大，所以注释掉了。需要 @aimoonchen 进一步确认。但我觉得编辑器最好用上新的 assetmgr.flush api 。比如在重新加载新场景时调用一下。flush 需要依赖 world 全部清空，然后重建所有 entity 。这样才可以保证没有任何 asset 的旧依赖。具体，见 https://github.com/ejoy/ant/pull/166/commits/13159ee0e7be647a1051a9981bd992f8b6c87c0b

第三步：增加 primitive 类型，取代 ant.entity 中的大部分 api 。

目前仅翻译了 ientity.plane_mesh 及 ientity.arrow_mesh 。和 ientity api 不同，primitive 的 mesh 是由 asset manager 管理的，它在 flush 之前只会创建一次。

使用 primitive ，可将之前的 ""ant.render|simplerender" 改用 "ant.render|render" ，不再直接构造 mesh_result 这个组件，而在 mesh 组件上声明 primitive 的名字。可以传参数，参数编码在字符串中。

这里的 plane 和 arrow 构造方法不统一，只是照搬了原有代码。建议 @junjie020 看看，把它们统一起来。另外，可增加诸如 cube 等基本几何体。
