### PR TITLE
Specify the exact version of Visual Studio

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -12,7 +12,7 @@ Ant is an open source game engine developed by Lingxi Interactive Entertainment.
 ### Build a Compilation Environment
 
 #### MSVC
-- Install Visual Studio
+- Install Visual Studio 2022 version 17.5 or later to ensure support for [C11 Atomics](https://devblogs.microsoft.com/visualstudio/visual-studio-2022-17-5-released/#atomics). Otherwise, you will encounter the error `stdatomic.h no such file or directory` during compilation.
 
 #### MINGW
 - Download and install [msys2](https://www.msys2.org/)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Ant 是由灵犀互娱开发的开源游戏引擎。现阶段仅将代码仓库�
 
 #### 1.1 Windows
 ##### 1.1.1 MSVC
-- 安装 Visual Studio
+- 安装 Visual Studio version 22 17.5 或以上版本，因为依赖对 [C11 Atomics](https://devblogs.microsoft.com/visualstudio/visual-studio-2022-17-5-released/#atomics) 的支持，不然编译时会出现 `stdatomic.h no such file or directory` 错误。
 
 ##### 1.1.2 MINGW
 - 下载并安装 [msys2](https://www.msys2.org/)


### PR DESCRIPTION
在一台安装 VS 2019 的电脑上编译 ant 时，出现了 `stdatomic.h no such file or directory` 错误，然后搜索确认了原因是 ant 使用了 C11 Atomics 。而 [VS 2022 Version 17.5](https://devblogs.microsoft.com/visualstudio/visual-studio-2022-17-5-released/#atomics) 才支持 C11 Atomics 。因此使用 VS 的最低版本便是 VS 2022 Version 17.5 。