### PR TITLE
Modify editor file menu

### DIFF
--- a/tools/editor/pkg/tools.editor/widget/menu.lua
+++ b/tools/editor/pkg/tools.editor/widget/menu.lua
@@ -51,11 +51,14 @@ function m.show()
     local camera_setting
     if ImGui.BeginMainMenuBar() then
         if ImGui.BeginMenu "File" then
-            if ImGui.MenuItemEx(faicons.ICON_FA_FILE_PEN.." New", "Ctrl+N") then
+            if ImGui.MenuItemEx(faicons.ICON_FA_FILE.." New", "Ctrl+N") then
                 world:pub {"ResetPrefab"}
             end
-            if ImGui.MenuItemEx(faicons.ICON_FA_FOLDER_OPEN.." Open", "Ctrl+O") then
-                world:pub{"OpenProject"}
+            if ImGui.MenuItemEx(faicons.ICON_FA_FILE_PEN.." Open File", "Ctrl+O") then
+                local filepath = uiutils.get_open_file_path("Select Prefab", "prefab")
+                if lfs.exists(filepath) then
+                    world:pub{"OpenFile", filepath, lfs.path(filepath):extension() == ".prefab"}
+                end
             end
             ImGui.Separator()
             if ImGui.BeginMenu(faicons.ICON_FA_LIST.." Recent Files") then


### PR DESCRIPTION
以前的 File/Open 按钮，看变量名是 Open Project 且抛出的 `world:pub{"OpenProject"}` 事件并没有被处理。实际上，在打开编辑器时就得指定 Project 目录了，目前似乎不需要这个功能而且还没有被实现。反而需要一个打开 .prefab 继续编辑的功能。

之前只能在 File/Recent Files 菜单中选择之前的文件进行编辑，无法主动打开一个 prefab 文件，因此就打算去掉以前的 File/Open 菜单，换成 File/Open File 菜单来主动打开 prefab ，现在截图如下。

![image](https://github.com/user-attachments/assets/2bcf5a58-2f7d-4c1e-9fa7-26d3ad2d4c35)
